### PR TITLE
fixing 0-0# and 0-0-0# cases in pgn-parser

### DIFF
--- a/js/pgn-parser.js
+++ b/js/pgn-parser.js
@@ -1384,6 +1384,7 @@ var pgnParser =
                             if (input.substr(peg$currPos, 5) === peg$c51) {
                                 s1 = peg$c51;
                                 peg$currPos += 5;
+                                peg$parsecheck();
                             } else {
                                 s1 = peg$FAILED;
                                 if (peg$silentFails === 0) { peg$fail(peg$c52); }
@@ -1398,6 +1399,7 @@ var pgnParser =
                                 if (input.substr(peg$currPos, 3) === peg$c54) {
                                     s1 = peg$c54;
                                     peg$currPos += 3;
+                                    peg$parsecheck();
                                 } else {
                                     s1 = peg$FAILED;
                                     if (peg$silentFails === 0) { peg$fail(peg$c55); }


### PR DESCRIPTION
I have been trying the PgnViewerJS library, and I have noticed that it fails to parse pgns with the 0-0# and 0-0-0# cases. I have found a way to make it work, but there is probably a better way to do it.

A pgn example of the case:

[Event "Chess 1944"]
[Site "Mate en 2 - 018866"]
[Date "1944.??.??"]
[Round "?"]
[White "Caine, Walter Edmond"]
[Black "#2 con 0-0"]
[Result "1-0"]
[Annotator "AjedrezPlus"]
[SetUp "1"]
[FEN "R7/8/8/8/3N4/1BB5/pr6/kb2K2R w K - 0 1"]
[PlyCount "3"]
[EventDate "1944.??.??"]
[EventCountry "ESP"]
[SourceDate "2017.01.09"]
[index "5"]

1. Bxa2 Bxa2 2. O-O# 1-0
