### PR TITLE
Make PgnViewerJS easy to use in different environments

### DIFF
--- a/modules/pgn-viewer/webpack.common.js
+++ b/modules/pgn-viewer/webpack.common.js
@@ -23,7 +23,7 @@ module.exports = {
         path: path.resolve(__dirname, 'lib'),
         publicPath: '/lib/',
         library: 'PGNV',
-        libraryTarget: "var",
+        libraryTarget: 'umd',
     },
     module: {
         rules: [

--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,8 @@ Due to the fact that Webpack holds the assets under a given directory (in my cas
 
 ### Using the viewer
 
+#### Standalone script
+
 To use the viewer in an HTML page, you have to do the following steps:
 
 * Include the necessary library `pgnv.js` and the corresponding resources `locales` and `pgnv-assets`.
@@ -94,17 +96,70 @@ To use the viewer in an HTML page, you have to do the following steps:
 
 So a rough template will look like:
 
-    <!DOCTYPE html>
-        <head>
-            <script src="js/pgnv.js" type="text/javascript" ></script>
-        </head>
-        <body>
-            <div id="board"></div>
-            <script>
-                PGNV.pgnView('board',{ pgn: '1. e4 e5 2. Nf3 Nc6 3. Bb5', pieceStyle: 'merida' });
-            </script>
-        </body>
-    </html>
+```html
+<!DOCTYPE html>
+    <head>
+        <script src="js/pgnv.js" type="text/javascript" ></script>
+    </head>
+    <body>
+        <div id="board"></div>
+        <script>
+    	PGNV.pgnView('board',{ pgn: '1. e4 e5 2. Nf3 Nc6 3. Bb5', pieceStyle: 'merida' });
+        </script>
+    </body>
+</html>
+```
+
+#### ReactJS
+
+```jsx
+import React, {useLayoutEffect} from 'react'
+import Children from 'react-children-utilities'
+import * as uuid from 'uuid'
+import { pgnView } from '@mliebelt/pgn-viewer'
+
+function PGNViewer(props) {
+  const gameDecription = Children.onlyText(props.children)
+  const id = 'board-' + uuid.v4()
+
+  useLayoutEffect(() => {
+    pgnView(id,
+      {
+        pgn: gameDecription,
+        timerTime: '1',
+        locale: 'pl',
+        startPlay: 1,
+        showResult: true,
+        boardSize: '340',
+        showFen: true,
+        pieceStyle: 'chesscom'
+      }
+    )
+  })
+
+  return (
+    <div id={id}></div>
+  )
+}
+
+// Usage
+
+<PGNViewer>
+[Event "F/S Return Match"]
+[Site "Belgrade"]
+[Date "1992.11.04"]
+[Round "29"]
+[White "Fischer, Robert J."]
+[Black "Spassky, Boris V."]
+[Result "1/2-1/2"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Nb8  10. d4 Nbd7
+11. c4 c6 12. cxb5 axb5 13. Nc3 Bb7 14. Bg5 b4 15. Nb1 h6 16. Bh4 c5 17. dxe5 Nxe4 18. Bxe7 Qxe7 19. exd6 Qf6 
+20. Nbd2 Nxd6 21. Nc4 Nxc4 22. Bxc4 Nb6 23. Ne5 Rae8 24. Bxf7+ Rxf7 25. Nxf7 Rxe1+ 26. Qxe1 Kxf7 27. Qe3 Qg5 
+28. Qxg5 hxg5 29. b3 Ke6 30. a3 Kd6 31. axb4 cxb4 32. Ra5 Nd5 33. f3 Bc8 34. Kf2 Bf5 35. Ra7 g6 36. Ra6+ Kc5 
+37. Ke1 Nf4 38. g3 Nxh3 39. Kd2 Kb5 40. Rd6 Kc5 41. Ra6 Nf2 42. g4 Bd3 43. Re6 1/2-1/2
+</PGNViewer>
+```
 
 ## Built With
 


### PR DESCRIPTION
#### Allow to use pgn-viewer with other import methods

Universal Module Definition is a way of building javascript library.
After this change it will be available from global variable, requirejs,
commonjs and es6 module.

#### Add example for ReactJS

Related: https://github.com/mliebelt/PgnViewerJS/issues/162