### PR TITLE
Bundle assets into single javascript file

### DIFF
--- a/modules/pgn-viewer/webpack.common.js
+++ b/modules/pgn-viewer/webpack.common.js
@@ -35,10 +35,7 @@ module.exports = {
                 test: /\.(png|jpg|gif|svg)$/,
                 use: [
                     {
-                        loader: 'file-loader',
-                        options: {
-                            outputPath: 'pgnv-assets',
-                        },
+                        loader: 'url-loader'
                     }
                 ]
             },

--- a/readme.md
+++ b/readme.md
@@ -76,13 +76,6 @@ There is at the moment no way to save a game that was edited in `pgnEdit` mode. 
 * Copy the files from the directory `modules/pgn-viewer/lib`.
 * Create new HTML files with the corresponding head and body.
 
-### About handling of assets
-
-Due to the fact that Webpack holds the assets under a given directory (in my case, it is `/lib/`). If you deploy the PgnViewerJS under any different root path, you have to define that root path by providing a Javascript line before loading the library:
-
-     <script>__globalCustomDomain = '/PgnViewerJS/js/';</script>
-     <script src="/PgnViewerJS/js/pgnv.js" type="text/javascript"></script>
-
 ### Using the viewer
 
 To use the viewer in an HTML page, you have to do the following steps:


### PR DESCRIPTION
#### Bundle assets into single javascript file

Related: https://github.com/mliebelt/PgnViewerJS/issues/170

There is not a lot of assets, but handling them is difficult. It can be
super easy when everything is in single file. There is
disadvantage of having bigger file.

File after bundle:

```
# before gzip
❯ more pgnv.js | wc -c
  641962
# after gzip
❯ gzip -c -9 pgnv.js | wc -c
  301743
```