### PR TITLE
Fixed: grayed board buttons

### DIFF
--- a/modules/pgn-viewer/src/css/pgnvjs.css
+++ b/modules/pgn-viewer/src/css/pgnvjs.css
@@ -235,6 +235,12 @@
     width: 500px;
 }
 
+.pgnvjs div.buttons > i.button.gray, div.buttons > i.button.gray:hover {
+    opacity: 0.5;
+    cursor: default;
+    border: solid var(--gray-300) 1px;
+}
+
 .pgnvjs div.nagMenu a {
     text-decoration: none;
     /*text-align: center;*/

--- a/modules/pgn-viewer/src/pgnvjs.js
+++ b/modules/pgn-viewer/src/pgnvjs.js
@@ -857,19 +857,19 @@ let pgnBase = function (boardId, configuration) {
      * Check which buttons should be grayed out
      */
     const updateUI = function (next) {
-        let elements = document.querySelectorAll("div.buttons .gray");
+        let elements = document.querySelectorAll("i.button.gray");
         utils.pvEach(elements, function (ele) {
             removeClass(ele, 'gray');
         });
         const move = that.mypgn.getMove(next);
         if (next === null) {
             ["prev", "first"].forEach(function (name) {
-                addClass(document.querySelector("div.buttons ." + name), 'gray');
+                addClass(document.querySelector("i#boardButton" + name), 'gray');
             });
         }
         if ((next !== null) && (typeof move.next != "number")) {
             ["next", "play", "last"].forEach(function (name) {
-                addClass(document.querySelector("div.buttons ." + name), 'gray');
+                addClass(document.querySelector("i#boardButton" + name), 'gray');
             });
         }
         // Update the drop-down for NAGs


### PR DESCRIPTION
Grayed board buttons implementation looks obsolette, does not work anymore.

This simple PR fixes it using similar approach + simple additional grayfying CSS.

**Note:** I am in fact working on the ticket #2 and this was one of the things I need to make more sophisticated navigation in PUZZLES working.